### PR TITLE
TYRUS-259 - Should produce a warning during deployment when OnMessage#ma...

### DIFF
--- a/client/src/main/java/org/glassfish/tyrus/client/ClientManager.java
+++ b/client/src/main/java/org/glassfish/tyrus/client/ClientManager.java
@@ -71,6 +71,7 @@ import org.glassfish.tyrus.core.ErrorCollector;
 import org.glassfish.tyrus.core.ReflectionHelper;
 import org.glassfish.tyrus.core.TyrusEndpointWrapper;
 import org.glassfish.tyrus.core.TyrusFuture;
+import org.glassfish.tyrus.core.Utils;
 import org.glassfish.tyrus.spi.ClientContainer;
 import org.glassfish.tyrus.spi.ClientEngine;
 
@@ -378,6 +379,8 @@ public class ClientManager extends BaseContainer implements WebSocketContainer {
                 final ErrorCollector collector = new ErrorCollector();
                 final ClientEndpointConfig config;
                 final Endpoint endpoint;
+                int incomingBufferSize = Utils.getProperty(copiedProperties, ClientContainer.INCOMING_BUFFER_SIZE,
+                        Integer.class, TyrusClientEngine.DEFAULT_INCOMING_BUFFER_SIZE);
 
                 try {
                     if (o instanceof Endpoint) {
@@ -389,7 +392,7 @@ public class ClientManager extends BaseContainer implements WebSocketContainer {
                             endpoint = ReflectionHelper.getInstance(((Class<Endpoint>) o), collector);
                             config = configuration == null ? ClientEndpointConfig.Builder.create().build() : configuration;
                         } else if ((((Class<?>) o).getAnnotation(ClientEndpoint.class) != null)) {
-                            endpoint = AnnotatedEndpoint.fromClass((Class) o, componentProvider, false, collector);
+                            endpoint = AnnotatedEndpoint.fromClass((Class) o, componentProvider, false, incomingBufferSize, collector);
                             config = (ClientEndpointConfig) ((AnnotatedEndpoint) endpoint).getEndpointConfig();
                         } else {
                             collector.addException(new DeploymentException(String.format("Class %s in not Endpoint descendant and does not have @ClientEndpoint", ((Class<?>) o).getName())));
@@ -397,7 +400,7 @@ public class ClientManager extends BaseContainer implements WebSocketContainer {
                             config = null;
                         }
                     } else {
-                        endpoint = AnnotatedEndpoint.fromInstance(o, componentProvider, false, collector);
+                        endpoint = AnnotatedEndpoint.fromInstance(o, componentProvider, false, incomingBufferSize, collector);
                         config = (ClientEndpointConfig) ((AnnotatedEndpoint) endpoint).getEndpointConfig();
                     }
 

--- a/client/src/main/java/org/glassfish/tyrus/client/TyrusClientEngine.java
+++ b/client/src/main/java/org/glassfish/tyrus/client/TyrusClientEngine.java
@@ -77,14 +77,18 @@ import org.glassfish.tyrus.spi.UpgradeResponse;
 import org.glassfish.tyrus.spi.Writer;
 
 /**
- * Tyrus {@link ClientEngine} implementaion.
+ * Tyrus {@link ClientEngine} implementation.
  *
  * @author Pavel Bucek (pavel.bucek at oracle.com)
  */
 public class TyrusClientEngine implements ClientEngine {
 
+    /**
+     * Default incoming buffer size for client container.
+     */
+    public static final int DEFAULT_INCOMING_BUFFER_SIZE = 4194315; // 4M (payload) + 11 (frame overhead)
+
     private static final Logger LOGGER = Logger.getLogger(TyrusClientEngine.class.getName());
-    private static final int DEFAULT_INCOMING_BUFFER_SIZE = 4194315; // 4M (payload) + 11 (frame overhead)
 
     private static final Version DEFAULT_VERSION = Version.DRAFT17;
     private static final int BUFFER_STEP_SIZE = 256;
@@ -181,17 +185,13 @@ public class TyrusClientEngine implements ClientEngine {
 
             listener.onSessionCreated(sessionForRemoteEndpoint);
 
-            final Object o = properties.get(ClientContainer.INCOMING_BUFFER_SIZE);
-            final int incomingBufferSize;
-            if (o != null && o instanceof Integer) {
-                incomingBufferSize = (Integer) o;
-            } else {
-                incomingBufferSize = DEFAULT_INCOMING_BUFFER_SIZE;
-            }
 
             return new Connection() {
 
-                private final ReadHandler readHandler = new TyrusReadHandler(protocolHandler, socket, incomingBufferSize, sessionForRemoteEndpoint.getNegotiatedExtensions(), extensionContext);
+                private final ReadHandler readHandler = new TyrusReadHandler(protocolHandler, socket,
+                        Utils.getProperty(properties, ClientContainer.INCOMING_BUFFER_SIZE, Integer.class, DEFAULT_INCOMING_BUFFER_SIZE),
+                        sessionForRemoteEndpoint.getNegotiatedExtensions(),
+                        extensionContext);
 
                 @Override
                 public ReadHandler getReadHandler() {

--- a/containers/grizzly-server/src/main/java/org/glassfish/tyrus/container/grizzly/server/GrizzlyServerContainer.java
+++ b/containers/grizzly-server/src/main/java/org/glassfish/tyrus/container/grizzly/server/GrizzlyServerContainer.java
@@ -96,21 +96,9 @@ public class GrizzlyServerContainer extends ServerContainerFactory {
             localProperties = new HashMap<String, Object>(properties);
         }
 
-        Object o = localProperties.get(TyrusWebSocketEngine.INCOMING_BUFFER_SIZE);
-        final Integer incomingBufferSize;
-        if (o != null && o instanceof Integer) {
-            incomingBufferSize = (Integer) o;
-        } else {
-            incomingBufferSize = null;
-        }
+        final Integer incomingBufferSize = Utils.getProperty(localProperties, TyrusWebSocketEngine.INCOMING_BUFFER_SIZE, Integer.class);
 
-        o = localProperties.get(ClusterContext.CLUSTER_CONTEXT);
-        final ClusterContext clusterContext;
-        if (o != null && o instanceof ClusterContext) {
-            clusterContext = (ClusterContext) o;
-        } else {
-            clusterContext = null;
-        }
+        final ClusterContext clusterContext = Utils.getProperty(localProperties, ClusterContext.CLUSTER_CONTEXT, ClusterContext.class);
 
         return new TyrusServerContainer((Set<Class<?>>) null) {
 

--- a/core/src/main/java/org/glassfish/tyrus/core/TyrusWebSocketEngine.java
+++ b/core/src/main/java/org/glassfish/tyrus/core/TyrusWebSocketEngine.java
@@ -299,7 +299,7 @@ public class TyrusWebSocketEngine implements WebSocketEngine {
 
         final ErrorCollector collector = new ErrorCollector();
 
-        AnnotatedEndpoint endpoint = AnnotatedEndpoint.fromClass(endpointClass, componentProviderService, true, collector);
+        AnnotatedEndpoint endpoint = AnnotatedEndpoint.fromClass(endpointClass, componentProviderService, true, incomingBufferSize, collector);
         EndpointConfig config = endpoint.getEndpointConfig();
 
         TyrusEndpointWrapper endpointWrapper = new TyrusEndpointWrapper(endpoint, config, componentProviderService, webSocketContainer,
@@ -335,7 +335,7 @@ public class TyrusWebSocketEngine implements WebSocketEngine {
         } else {
             final ErrorCollector collector = new ErrorCollector();
 
-            final AnnotatedEndpoint endpoint = AnnotatedEndpoint.fromClass(serverConfig.getEndpointClass(), componentProviderService, true, collector);
+            final AnnotatedEndpoint endpoint = AnnotatedEndpoint.fromClass(serverConfig.getEndpointClass(), componentProviderService, true, incomingBufferSize, collector);
             final EndpointConfig config = endpoint.getEndpointConfig();
 
             endpointWrapper = new TyrusEndpointWrapper(endpoint, config, componentProviderService, webSocketContainer,

--- a/core/src/main/java/org/glassfish/tyrus/core/Utils.java
+++ b/core/src/main/java/org/glassfish/tyrus/core/Utils.java
@@ -344,6 +344,19 @@ public class Utils {
      * @return typed value or {@code null} if property is not set or value is not assignable.
      */
     public static <T> T getProperty(Map<String, Object> properties, String key, Class<T> type) {
+        return getProperty(properties, key, type, null);
+    }
+
+    /**
+     * Get typed property from generic property map.
+     *
+     * @param properties   property map.
+     * @param key          key of value to be retrieved.
+     * @param type         type of value to be retrieved.
+     * @param defaultValue value returned when record does not exist in supplied map.
+     * @return typed value or {@code null} if property is not set or value is not assignable.
+     */
+    public static <T> T getProperty(Map<String, Object> properties, String key, Class<T> type, T defaultValue) {
         if (properties != null) {
             final Object o = properties.get(key);
             if (o != null && type.isAssignableFrom(o.getClass())) {
@@ -352,6 +365,6 @@ public class Utils {
             }
         }
 
-        return null;
+        return defaultValue;
     }
 }

--- a/core/src/main/resources/org/glassfish/tyrus/core/l10n/localization.properties
+++ b/core/src/main/resources/org/glassfish/tyrus/core/l10n/localization.properties
@@ -70,6 +70,7 @@ endpoint.wrong.path.param=Method: {0}: {1} is not allowed type for @PathParamete
 endpoint.multiple.session.param=Method {0} has got two or more Session parameters.
 endpoint.exception.from.on.error=Exception thrown from onError method {0}.
 endpoint.unhandled.exception=Unhandled exception in endpoint {0}.
+endpoint.max.message.size.too.long=MaxMessageSize {0} on method {1} in endpoint {2} is larger than the container incoming buffer size {3}.
 
 buffer.overflow=Buffer overflow.
 partial.message.buffer.overflow=Partial message could not be delivered due to buffer overflow.

--- a/tests/e2e/non-deployable/src/test/java/org/glassfish/tyrus/test/e2e/non_deployable/MaxMessageSizeDeploymentTest.java
+++ b/tests/e2e/non-deployable/src/test/java/org/glassfish/tyrus/test/e2e/non_deployable/MaxMessageSizeDeploymentTest.java
@@ -1,0 +1,240 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.tyrus.test.e2e.non_deployable;
+
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import javax.websocket.ClientEndpoint;
+import javax.websocket.DeploymentException;
+import javax.websocket.OnMessage;
+import javax.websocket.server.ServerEndpoint;
+
+import org.glassfish.tyrus.client.ClientManager;
+import org.glassfish.tyrus.core.AnnotatedEndpoint;
+import org.glassfish.tyrus.core.TyrusWebSocketEngine;
+import org.glassfish.tyrus.core.l10n.LocalizationMessages;
+import org.glassfish.tyrus.server.Server;
+import org.glassfish.tyrus.spi.ClientContainer;
+import org.glassfish.tyrus.test.tools.TestContainer;
+
+import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests warnings logged when max message size given in {@link javax.websocket.OnMessage} is larger than max message
+ * size specified in a container.
+ *
+ * @author Petr Janouch (petr.janouch at oracle.com)
+ */
+public class MaxMessageSizeDeploymentTest extends TestContainer {
+
+    private final Logger logger = Logger.getLogger(AnnotatedEndpoint.class.getName());
+
+    @ServerEndpoint("/largeMaxMessageSizeServerEndpoint")
+    public static class LargeMaxMessageSizeServerEndpoint {
+
+        @OnMessage(maxMessageSize = 2)
+        public void onTooBigMessage(String message) {
+        }
+    }
+
+    @Test
+    public void serverMaxMessageSizeTooLargeTest() throws DeploymentException, InterruptedException, IOException {
+        Map<String, Object> serverProperties = getServerProperties();
+        serverProperties.put(TyrusWebSocketEngine.INCOMING_BUFFER_SIZE, 1);
+        final AtomicBoolean warningLogged = new AtomicBoolean(false);
+        LoggerHandler handler = new LoggerHandler() {
+            @Override
+            public void publish(LogRecord record) {
+                String expectedWarningMessage = LocalizationMessages.ENDPOINT_MAX_MESSAGE_SIZE_TOO_LONG(2, LargeMaxMessageSizeServerEndpoint.class.getMethods()[0].getName(), LargeMaxMessageSizeServerEndpoint.class.getName(), 1);
+                System.out.println("Expected message: " + expectedWarningMessage);
+                System.out.println("Logged message: " + record.getMessage());
+                if (expectedWarningMessage.equals(record.getMessage())) {
+                    warningLogged.set(true);
+                }
+            }
+        };
+        logger.setLevel(Level.CONFIG);
+        logger.addHandler(handler);
+        Server server = null;
+        try {
+            server = startServer(LargeMaxMessageSizeServerEndpoint.class);
+        } finally {
+            stopServer(server);
+        }
+        assertTrue(warningLogged.get());
+        logger.removeHandler(handler);
+    }
+
+    /**
+     * Tests that no warning is given during server endpoint deployment.
+     * It does not look for a specific message, but checks that no warning is given, therefore it
+     * might fail, when other warnings than max message size check are introduced.
+     */
+    @Test
+    public void serverMaxMessageSizeOkTest() throws DeploymentException, InterruptedException, IOException {
+        Map<String, Object> serverProperties = getServerProperties();
+        serverProperties.put(TyrusWebSocketEngine.INCOMING_BUFFER_SIZE, 3);
+        final AtomicBoolean warningLogged = new AtomicBoolean(false);
+        LoggerHandler handler = new LoggerHandler() {
+            @Override
+            public void publish(LogRecord record) {
+                System.out.println("Logged message: " + record.getMessage());
+                warningLogged.set(true);
+            }
+        };
+        logger.setLevel(Level.CONFIG);
+        logger.addHandler(handler);
+        Server server = null;
+        try {
+            server = startServer(LargeMaxMessageSizeServerEndpoint.class);
+        } finally {
+            stopServer(server);
+        }
+        assertFalse(warningLogged.get());
+        logger.removeHandler(handler);
+    }
+
+    @ClientEndpoint
+    public static class LargeMaxMessageSizeClientEndpoint {
+
+        @OnMessage(maxMessageSize = 2)
+        public void onTooBigMessage(String message) {
+        }
+
+    }
+
+    @ServerEndpoint("/dummyServerEndpoint")
+    public static class DummyServerEndpoint {
+
+    }
+
+    @Test
+    public void clientMaxMessageSizeTooLargeTest() throws DeploymentException {
+        Server server = startServer(DummyServerEndpoint.class);
+        try {
+            ClientManager client = createClient();
+            Map<String, Object> properties = client.getProperties();
+            properties.put(ClientContainer.INCOMING_BUFFER_SIZE, 1);
+            final AtomicBoolean warningLogged = new AtomicBoolean(false);
+            LoggerHandler handler = new LoggerHandler() {
+                @Override
+                public void publish(LogRecord record) {
+                    String expectedWarningMessage = LocalizationMessages.ENDPOINT_MAX_MESSAGE_SIZE_TOO_LONG(2, LargeMaxMessageSizeClientEndpoint.class.getMethods()[0].getName(), LargeMaxMessageSizeClientEndpoint.class.getName(), 1);
+                    System.out.println("Expected message: " + expectedWarningMessage);
+                    System.out.println("Logged message: " + record.getMessage());
+                    if (expectedWarningMessage.equals(record.getMessage())) {
+                        warningLogged.set(true);
+                    }
+                }
+            };
+            logger.setLevel(Level.CONFIG);
+            logger.addHandler(handler);
+            client.connectToServer(LargeMaxMessageSizeClientEndpoint.class, getURI(DummyServerEndpoint.class, "ws"));
+            assertTrue(warningLogged.get());
+            logger.removeHandler(handler);
+
+        } catch (IOException e) {
+
+        } finally {
+            stopServer(server);
+        }
+    }
+
+    /**
+     * Tests that no warning is given during client endpoint deployment.
+     * It does not look for a specific message, but checks that no warning is given, therefore it
+     * might fail, when other warnings than max message size check are introduced.
+     */
+    @Test
+    public void clientMaxMessageSizeOkTest() throws DeploymentException {
+        Server server = startServer(DummyServerEndpoint.class);
+        try {
+            ClientManager client = createClient();
+            Map<String, Object> properties = client.getProperties();
+            properties.put(ClientContainer.INCOMING_BUFFER_SIZE, 3);
+            final AtomicBoolean warningLogged = new AtomicBoolean(false);
+            LoggerHandler handler = new LoggerHandler() {
+                @Override
+                public void publish(LogRecord record) {
+                    System.out.println("Logged message: " + record.getMessage());
+                    warningLogged.set(true);
+                }
+            };
+            logger.setLevel(Level.CONFIG);
+            logger.addHandler(handler);
+            client.connectToServer(LargeMaxMessageSizeClientEndpoint.class, getURI(DummyServerEndpoint.class, "ws"));
+            assertFalse(warningLogged.get());
+            logger.removeHandler(handler);
+
+        } catch (IOException e) {
+
+        } finally {
+            stopServer(server);
+        }
+    }
+
+    private static abstract class LoggerHandler extends Handler {
+
+        @Override
+        public void flush() {
+
+        }
+
+        @Override
+        public void close() throws SecurityException {
+
+        }
+
+        @Override
+        public synchronized Level getLevel() {
+            return Level.CONFIG;
+        }
+    }
+
+}


### PR DESCRIPTION
...xMessageSize is larger than the value of org.glassfish.tyrus.servlet.incoming-buffer-size.

Also added validation of OnMessage#maxMessageSize against org.glassfish.tyrus.incomingBufferSize when deploying annotated endpoint on a client and Grizzly server.
