### PR TITLE
ServletWriter - adding item to task queue before setWriteListener(...) i...

### DIFF
--- a/containers/servlet/src/main/java/org/glassfish/tyrus/servlet/TyrusServletWriter.java
+++ b/containers/servlet/src/main/java/org/glassfish/tyrus/servlet/TyrusServletWriter.java
@@ -132,13 +132,13 @@ class TyrusServletWriter extends Writer implements WriteListener {
         if (queue.isEmpty() && servletOutputStream.isReady()) {
             _write(buffer, completionHandler);
         } else {
+            final QueuedFrame queuedFrame = new QueuedFrame(completionHandler, buffer);
+            queue.offer(queuedFrame);
+
             if (!isListenerSet) {
                 isListenerSet = true;
                 servletOutputStream.setWriteListener(this);
             }
-
-            final QueuedFrame queuedFrame = new QueuedFrame(completionHandler, buffer);
-            queue.offer(queuedFrame);
         }
     }
 


### PR DESCRIPTION
...s called
- solves the issue when onWritePossible() is invoked right when registration is done and from the same thread. Current implementation will leave the task in queue until next one arrives.
