### PR TITLE
Minimal thread pool size in client ThreadPoolConfig increased from 2 to ...

### DIFF
--- a/client/src/main/java/org/glassfish/tyrus/client/ThreadPoolConfig.java
+++ b/client/src/main/java/org/glassfish/tyrus/client/ThreadPoolConfig.java
@@ -255,14 +255,14 @@ public final class ThreadPoolConfig {
     /**
      * Set max thread pool size. The default is The default is {@code Math.max(Runtime.getRuntime().availableProcessors(), 20)}.
      * <p/>
-     * Cannot be smaller than 2.
+     * Cannot be smaller than 3.
      *
      * @param maxPoolSize the max thread pool size.
      * @return the {@link ThreadPoolConfig} with the new max pool size set.
      */
     public ThreadPoolConfig setMaxPoolSize(int maxPoolSize) {
-        if (maxPoolSize < 2) {
-            throw new IllegalArgumentException("Max thread pool size cannot be smaller than 2");
+        if (maxPoolSize < 3) {
+            throw new IllegalArgumentException("Max thread pool size cannot be smaller than 3");
         }
 
         this.maxPoolSize = maxPoolSize;

--- a/containers/jdk-client/src/test/java/org/glassfish/tyrus/container/jdk/client/ThreadPoolSizeLimitsTest.java
+++ b/containers/jdk-client/src/test/java/org/glassfish/tyrus/container/jdk/client/ThreadPoolSizeLimitsTest.java
@@ -82,14 +82,14 @@ public class ThreadPoolSizeLimitsTest extends TestContainer {
         assertEquals(0, config.getCorePoolSize());
 
         try {
-            config.setMaxPoolSize(1);
+            config.setMaxPoolSize(2);
             fail();
         } catch (Exception e) {
             // do nothing
         }
 
-        config.setMaxPoolSize(2);
-        assertEquals(2, config.getMaxPoolSize());
+        config.setMaxPoolSize(3);
+        assertEquals(3, config.getMaxPoolSize());
 
         config.setQueueLimit(-2);
         assertEquals(-1, config.getQueueLimit());
@@ -112,7 +112,7 @@ public class ThreadPoolSizeLimitsTest extends TestContainer {
 
 
             ClientManager client = ClientManager.createClient(JdkClientContainer.class.getName());
-            ThreadPoolConfig config = ThreadPoolConfig.defaultConfig().setMaxPoolSize(2);
+            ThreadPoolConfig config = ThreadPoolConfig.defaultConfig().setMaxPoolSize(3);
             client.getProperties().put(ClientProperties.WORKER_THREAD_POOL_CONFIG, config);
 
             client.connectToServer(new Endpoint() {


### PR DESCRIPTION
...3

```
(Client needs minimally 3 worker threads to work on Windows)
```
