### PR TITLE
Ignore test for tyrus.test.port other than 80

### DIFF
--- a/tests/e2e/non-deployable/src/test/java/org/glassfish/tyrus/test/e2e/non_deployable/DefaultPortTest.java
+++ b/tests/e2e/non-deployable/src/test/java/org/glassfish/tyrus/test/e2e/non_deployable/DefaultPortTest.java
@@ -57,18 +57,15 @@ import javax.websocket.server.ServerEndpoint;
 import org.glassfish.tyrus.server.Server;
 import org.glassfish.tyrus.test.tools.TestContainer;
 
-import org.junit.Ignore;
+import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * @author Pavel Bucek (pavel.bucek at oracle.com)
  */
 public class DefaultPortTest extends TestContainer {
-
-    public DefaultPortTest() {
-        setDefaultPort(80);
-    }
 
     @ServerEndpoint(value = "/default-port-echo")
     public static class EchoEndpoint {
@@ -78,14 +75,19 @@ public class DefaultPortTest extends TestContainer {
         }
     }
 
-    @Ignore("need root to open port 80")
+    @Before
+    public void before() {
+        assumeTrue(getPort() == 80);
+    }
+
     @Test
     public void testDefaultWsPort() throws DeploymentException {
+
         Server server = startServer(EchoEndpoint.class);
 
         final CountDownLatch messageLatch = new CountDownLatch(1);
 
-        final URI uri = URI.create("ws://localhost/e2e-test/default-port-echo");
+        final URI uri = getURI(EchoEndpoint.class);
 
         try {
             final ClientEndpointConfig cec = ClientEndpointConfig.Builder.create().build();

--- a/tests/tools/src/main/java/org/glassfish/tyrus/test/tools/TestContainer.java
+++ b/tests/tools/src/main/java/org/glassfish/tyrus/test/tools/TestContainer.java
@@ -169,7 +169,15 @@ public class TestContainer {
      */
     protected URI getURI(String endpointPath, String scheme) {
         try {
-            return new URI(scheme == null ? "ws" : scheme, null, getHost(), getPort(), contextPath + endpointPath, null, null);
+            String currentScheme = scheme == null ? "ws" : scheme;
+            int port = getPort();
+
+            if ((port == 80 && "ws".equalsIgnoreCase(currentScheme))
+                    || (port == 443 && "wss".equalsIgnoreCase(currentScheme))) {
+                port = -1;
+            }
+
+            return new URI(currentScheme, null, getHost(), port, contextPath + endpointPath, null, null);
         } catch (URISyntaxException e) {
             e.printStackTrace();
             return null;


### PR DESCRIPTION
Default port test cannot be run without root permissions, but we will be able to explicitly run it. Otherwise will be ignored.
