### PR TITLE
Sample echo-basic-auth fixes.

### DIFF
--- a/samples/echo-basic-auth/README.html
+++ b/samples/echo-basic-auth/README.html
@@ -49,6 +49,11 @@
 
 <p>This sample demonstrates how to configure Tyrus client to connect on access protected server endpoint over HTTPS.</p>
 
+<p><i>
+    Should be noted that we were able to run this sample only on Firefox (v27.01). Chrome (v37) and Safari (v7.0.5)
+    do not handle HTTP authentication during a websocket handshake properly.
+</i></p>
+
 <h2>Contents</h2>
 
 <p>

--- a/samples/echo-basic-auth/src/main/webapp/index.html
+++ b/samples/echo-basic-auth/src/main/webapp/index.html
@@ -48,7 +48,7 @@
 <meta charset="utf-8">
 <title>Web Socket JavaScript Basic Auth Client</title>
 <script language="javascript" type="text/javascript">
-    var wsUri = getRootUri() + "/sample-basic-auth/basic-auth-echo";
+    var wsUri = getRootUri() + "/sample-echo-basic-auth/basic-auth-echo";
 
     function getRootUri() {
         return "wss://" + (document.location.hostname == "" ? "localhost" : document.location.hostname) + ":" +


### PR DESCRIPTION
- wrong context-root in index.html
- modified readme.html (only firefox can handle auth during a handshake)
